### PR TITLE
Format Activity Schedule and Pack Leadership as a Table

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,16 +119,43 @@
 				<header>
 					<h2>Typical Activity Schedule</h2>
 				</header>
-				<p>January - Pinewood Derby<br>
-				   February - Blue & Gold Banquet<br>
-				   April - Rocket Launch<br>
-				   May - Pack Campout & Crossover<br>
-				   June - Elizabeth Stampede Community Service<br>
-				   September - Join night, breakfast burrito fundraiser<br>
-				   October - Rain Gutter Regatta<br>
-				   November - Veterans Day assembly<br>
+                <table class="table-borderless">
+                  <tbody>
+                    <tr>
+                      <td>January</td>
+                      <td>Pinewood Derby</td>
+                    </tr>
+                    <tr>
+                      <td>February</td>
+                      <td>Blue &amp; Gold Banquet</td>
+                    </tr>
+                    <tr>
+                      <td>April</td>
+                      <td>Rocket Launch</td>
+                    </tr>
+                    <tr>
+                      <td>May</td>
+                      <td>Pack Campout &amp; Crossover</td>
+                    </tr>
+                    <tr>
+                      <td>June</td>
+                      <td>Elizabeth Stampede Community Service</td>
+                    </tr>
+                    <tr>
+                      <td>September</td>
+                      <td>Join night, breakfast burrito fundraiser</td>
+                    </tr>
+                    <tr>
+                      <td>October</td>
+                      <td>Rain Gutter Regatta</td>
+                    </tr>
+                    <tr>
+                      <td>November</td>
+                      <td>Veterans Day assembly</td>
+                    </tr>
+                  </tbody>
+                </table>
 
-				</p>
 			</article>
 		</section>		
 

--- a/index.html
+++ b/index.html
@@ -142,41 +142,46 @@
 				<header>
 					<h2>Pack Leadership</h2>
 				</header>
-				<div class="column-container">
-					<div class="column">
-					  <p>Cubmaster</p>
-					  <p>Committee Chair</p>
-					  <p>Charter Org Rep</p>
-					  <p>Treasurer</p>
-					  <p>Fundraising Chair</p>
-					  <p>Webelos Den Leader</p>
-					  <p>Bear Den Leader</p>
-					  <p>Wolf Den Leader</p>
-					  <p>Tiger Den Leader</p>
-					</div>
-					<div class="column">
-					  <p>Mitchell Scott</p>
-					  <p>Tanya Spiridon-Wise</p>
-					  <p>Amy Malleck</p>
-					  <p>Valerie Kanelopoulos</p>
-					  <p>Janet Clark</p>
-					  <p>Tracy Strunk</p>
-					  <p>Rudy Renka</p>
-					  <p>Shawn Donahue</p>
-					  <p>Faith Gregory</p>
-					</div>
-				  </div>
-				<!-- <p>
-				Cubmaster - Mitchell Scott<br>
-				Committee Chair - Tanya Spiridon-Wise<br>
-				Charter Organization Rep - Amy Malleck<br>
-				Treasurer - Valerie Kanelopoulos<br>
-				Fundraising Chair - Janet Clark<br>
-				Webelos Den Leader - Tracy Strunk<br>
-				Bear Den Leader - Rudy Renka<br>
-				Wolf Den Leader - Shawn Donahue<br>
-				Tiger Den Leader - Faith Gregory<br>
-				</p> -->
+                <table class="table-borderless">
+                  <tbody>
+                    <tr>
+                      <td>Cubmaster</td>
+                      <td>Mitchell Scott</td>
+                    </tr>
+                    <tr>
+                      <td>Committee Chair</td>
+                      <td>Tanya Spiridon-Wise</td>
+                    </tr>
+                    <tr>
+                      <td>Charter Org Rep</td>
+                      <td>Amy Malleck</td>
+                    </tr>
+                    <tr>
+                      <td>Treasurer</td>
+                      <td>Valerie Kanelopoulos</td>
+                    </tr>
+                    <tr>
+                      <td>Fundraising Chair</td>
+                      <td>Janet Clark</td>
+                    </tr>
+                    <tr>
+                      <td>Webelos Den Leader</td>
+                      <td>Tracy Strunk</td>
+                    </tr>
+                    <tr>
+                      <td>Bear Den Leader</td>
+                      <td>Rudy Renka</td>
+                    </tr>
+                    <tr>
+                      <td>Wolf Den Leader</td>
+                      <td>Shawn Donahue</td>
+                    </tr>
+                    <tr>
+                      <td>Tiger Den Leader</td>
+                      <td>Faith Gregory</td>
+                    </tr>
+                  </tbody>
+                </table>
 			</article>
 		</section>	
 

--- a/style.css
+++ b/style.css
@@ -309,7 +309,7 @@ td, th {
 tr:nth-child(even) {
     background-color: #edf5ff;
 }
-@media screen and (max-width: 400px) {
+@media screen and (max-width: 576px) {
     td, th {
         padding: 5px;
     }

--- a/style.css
+++ b/style.css
@@ -295,11 +295,25 @@ table {
 	border-collapse:collapse;
 }
 table, td, th {border: 1px solid #003F87;}
+.table-borderless, .table-borderless td, .table-borderless th {
+    border: none;
+}
 th {
 	color: #fff;
 	background-color: #003F87;
 }
-td, th {padding: 5px;}
+td, th {
+    padding: 2px 5px;
+    vertical-align: middle;
+}
+tr:nth-child(even) {
+    background-color: #edf5ff;
+}
+@media screen and (max-width: 400px) {
+    td, th {
+        padding: 5px;
+    }
+}
 
 /* -------------------- Blockquotes --------------------*/
 blockquote {


### PR DESCRIPTION
This PR formats the Activity Schedule and Pack Leadership as a table.

Example:
![image](https://user-images.githubusercontent.com/7717888/236121692-86a21aa4-acbb-4779-a6af-67976f39d13f.png)


If you prefer, this could be formatted with headers and borders. Let me know and I can change it to this:
![image](https://user-images.githubusercontent.com/7717888/236122102-1041e98f-ec25-4000-a2ac-96619f120a0e.png)
